### PR TITLE
CNSIMSU24-23, CNSIMSU24-24 - Block Revamp

### DIFF
--- a/src/cmg/cnsim/bitcoin/Block.java
+++ b/src/cmg/cnsim/bitcoin/Block.java
@@ -6,6 +6,7 @@ import cmg.cnsim.engine.transaction.Transaction;
 import cmg.cnsim.engine.transaction.TransactionGroup;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 /**
  * 
@@ -44,7 +45,7 @@ public class Block extends TransactionGroup implements Cloneable {
 	protected int height = 0;
 
 	
-	//The times the block was validated 
+	//The times the block was validated
 	private long simTime_validation = -1;
 	private long sysTime_validation = -1;
 	
@@ -306,4 +307,26 @@ public class Block extends TransactionGroup implements Cloneable {
 	protected Object clone() throws CloneNotSupportedException {
 		return super.clone();
 	}
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        Block block = (Block) other;
+        return height == block.height
+                && simTime_validation == block.simTime_validation
+                && sysTime_validation == block.sysTime_validation
+                && validationNodeID == block.validationNodeID
+                && currentNodeID == block.currentNodeID
+                && Double.compare(validationDifficulty, block.validationDifficulty) == 0
+                && Double.compare(validationCycles, block.validationCycles) == 0
+                && Objects.equals(contx, block.contx)
+                && Objects.equals(parent, block.parent)
+                && Objects.equals(lastBlockEvent, block.lastBlockEvent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(contx, parent, height, simTime_validation, sysTime_validation, validationNodeID, currentNodeID, validationDifficulty, validationCycles, lastBlockEvent);
+    }
 }

--- a/src/cmg/cnsim/bitcoin/Block.java
+++ b/src/cmg/cnsim/bitcoin/Block.java
@@ -1,6 +1,5 @@
 package cmg.cnsim.bitcoin;
 
-import cmg.cnsim.engine.Simulation;
 import cmg.cnsim.engine.node.Node;
 import cmg.cnsim.engine.transaction.Transaction;
 import cmg.cnsim.engine.transaction.TransactionGroup;
@@ -9,304 +8,155 @@ import java.util.ArrayList;
 import java.util.Objects;
 
 /**
- * 
  * The Block class represents a block in a blockchain. It extends the TransactionGroup class.
  *
  * @author Sotirios Liaskos for the Enterprise Systems Group @ York University
- *
  */
 public class Block extends TransactionGroup implements Cloneable {
-	
-	// Generation of next unique ID for new blocks.
-	public static int currID = 1;
-	
+
+    // =========================
+    // ID Generation & Management
+    // =========================
+
+    private static int currID = 1;
+
+    public static int getNextID() {
+        return currID++;
+    }
+
+    // ========================
+    // Fields for Reporting & Blockchain Structure
+    // =========================
+
+    // Parent in blockchain (if any)
+    protected TransactionGroup parent = null;
+
+    // Height in blockchain (if in one)
+    protected int height = 0;
 
 
-	public static int getCurrID() {
-		return currID;
-	}
+    // Times the block was validated
+    private long simTime_validation = -1;
+    private long sysTime_validation = -1;
+
+    // ID of the node that validated the block
+    private int validationNodeID = -1;
+
+    // Node currently in possession of the block
+    private int currentNodeID = -1;
+
+    // Difficulty under which validation took place
+    private double validationDifficulty = -1;
+
+    // Cycles dedicated for the validation of the block
+    private double validationCycles = -1;
+
+    // Last event that happened to the block
+    private String lastBlockEvent = "-1";
 
 
-	public static void setCurrID(int currID) {
-		Block.currID = currID;
-	}
-
-
-	public static int getNextID() {
-		return(currID++);
-	}
-	
-	//Holds information for reporting purposes
-	public Context contx;
-	
-	//The parent in blockchain (if any)
-	protected TransactionGroup parent = null;
-	//The height in blockchain (if in one)
-	protected int height = 0;
-
-	
-	//The times the block was validated
-	private long simTime_validation = -1;
-	private long sysTime_validation = -1;
-	
-	//The id of the node that validated the block
-	private int validationNodeID = -1;
-	
-	//The node currently in possession of the block
-	private int currentNodeID = -1;
-	
-	//The difficulty under which validation took place
-	private double validationDifficulty = -1;
-	
-	//The cycles dedicated for the validation of the block
-	private double validationCycles = -1;
-	
-	//The last event that happened to the block
-	private String lastBlockEvent = "-1";
-	
-	
-
-
-
-	/**
-	 * Information about the lifecycle of the block.
-	 */
-	public class Context {
-		public long simTime;
-		public long sysTime;
-		public int nodeID;
-		public String blockEvt;
-		public double difficulty;
-		public double cycles;
-	}
-	
+    public Context context;
 
     /**
-     * Returns the information context of the block.
-     *
-     * @return The information context of the block.
+     * Contains information about the lifecycle of the block.
      */
-	public Context getContext(){
-		return(this.contx);
-	}
-	
-	
-	/**
-	 * @deprecated
-	 */
-	public void ____________Constructors() {}
-	
+    public static class Context {
+        public long simTime;
+        public long sysTime;
+        public int nodeID;
+        public String blockEvt;
+        public double difficulty;
+        public double cycles;
+    }
+
+    // =========================
+    // Constructors
+    // =========================
+
     /**
      * Constructs a new {@link Block} object with the next available ID and an empty {@link Context}.
      */
-	public Block(){
-		contx = new Context();
-		groupID = getNextID();
-	}
-	
+    public Block() {
+        context = new Context();
+        groupID = getNextID();
+    }
+
     /**
-     * Constructs a new {@link Block} object with the next available ID and an initial list 
-     * of {@link Transaction} objects and an empty context. 
+     * Constructs a new {@link Block} object with the next available ID and an initial lis of {@link Transaction}
+     * objects and an empty context.
+     *
      * @param initial The initial list of {@link Transaction} objects.
      */
     public Block(ArrayList<Transaction> initial) {
-    	super(initial);
-		contx = new Context();
-    	groupID = getNextID();
+        super(initial);
+        context = new Context();
+        groupID = getNextID();
     }
-	
-    
+
+    // =========================
+    // Utility Methods
+    // =========================
+
     /**
-     * Updates {@linkplain Block} with information pertaining to its validation.
-     * Used in response to a validation event. 
-     * @param newTransList The list of {@link Transaction} objects that are validated. 
-     * @param simTime Simulation time at which the validation event occurred.
-     * @param sysTime Real time at which the validation event occurred.
-     * @param nodeID ID of the {@link Node} in which validation took place.
-     * @param eventType Textual description of the type of event (for logging).
-     * TODO: link to difficulty explanation.
-     * @param difficulty Difficulty under which validation took place. 
-     * TODO: check if this is correct.
-     * @param cycles The number of cycles (hashes) expended for the validation. 
+     * Updates {@linkplain Block} with information pertaining to its validation. Used in response to a validation event.
+     *
+     * @param newTransList The list of {@link Transaction} objects that are validated.
+     * @param simTime      Simulation time at which the validation event occurred.
+     * @param sysTime      Real time at which the validation event occurred.
+     * @param nodeID       ID of the {@link Node} in which validation took place.
+     * @param eventType    Textual description of the type of event (for logging).
+     *                     TODO: link to difficulty explanation.
+     * @param difficulty   Difficulty under which validation took place.
+     *                     TODO: check if this is correct.
+     * @param cycles       The number of cycles (hashes) expended for the validation.
      */
-    public void validateBlock(ArrayList<Transaction> newTransList,
-    		long simTime,
-    		long sysTime,
-    		int nodeID,
-    		String eventType,
-    		double difficulty,
-    		double cycles
-    		) {
-    	super.updateTransactionGroup(newTransList);
+    public void validateBlock(
+            ArrayList<Transaction> newTransList,
+            long simTime,
+            long sysTime,
+            int nodeID,
+            String eventType,
+            double difficulty,
+            double cycles
+    ) {
+        super.updateTransactionGroup(newTransList);
 //    	groupID = getID();
-    	
-    	simTime_validation = simTime;
-    	sysTime_validation = sysTime;
-    	validationNodeID = nodeID;
-    	currentNodeID = nodeID;
-    	
-    	validationDifficulty = difficulty;
-    	validationCycles = cycles;
-    	
-    	//Deprecated
-    	contx = new Context();
-		contx.simTime = simTime;
-		contx.sysTime = sysTime;
-		contx.nodeID = nodeID;
-		contx.blockEvt = eventType;
-		contx.difficulty = difficulty;
-		contx.cycles = cycles;
+
+        simTime_validation = simTime;
+        sysTime_validation = sysTime;
+        validationNodeID = nodeID;
+        currentNodeID = nodeID;
+
+        validationDifficulty = difficulty;
+        validationCycles = cycles;
+
+        // Deprecated
+        context = new Context();
+        context.simTime = simTime;
+        context.sysTime = sysTime;
+        context.nodeID = nodeID;
+        context.blockEvt = eventType;
+        context.difficulty = difficulty;
+        context.cycles = cycles;
     }
-    
-  
-	//
-	//
-	// HEIGHT in BLOCKCHAIN
-	//
-	//
-    /**
-     * @deprecated
-     */
-	public void _________HeightAndParents() {}
-	
-	
-	/**
-	 * Returns the height of the {@linkplain Block} in a blockchain.
-	 * @return The height of the {@linkplain Block} in a blockchain.
-	 */
-	public int getHeight() {
-		return(height);
-	}
 
-	/**
-	 * Sets the height of the {@linkplain Block} in a blockchain.
-	 * @param height The height of the {@linkplain Block} in a blockchain.
-	 */
-	public void setHeight(int height) {
-		this.height = height; 
-	}
-	
-	
-	//
-	//
-	// PARENTHOOD
-	//
-	//
-    /**
-     * Returns the parent {@linkplain TransactionGroup} of the {@linkplain Block}.
-     *
-     * @return The parent parent {@linkplain TransactionGroup} of the {@linkplain Block}.
-     */
-	public TransactionGroup getParent() {
-		return(parent);
-	}
-	
-	
-    /**
-     * Sets the parent of the {@linkplain Block}.
-     *
-     * @param parent The {@linkplain TransactionGroup} to be set as parent.
-     */
-	public void setParent(TransactionGroup parent) {
-		this.parent = parent;
-	}
-
-	
     /**
      * Checks if the {@linkplain Block} has a parent.
      *
      * @return {@code true} if the block has a parent, {@code false} otherwise.
      */
-	public boolean hasParent() {
-		return (parent != null);
-	}
+    public boolean hasParent() {
+        return parent != null;
+    }
 
+    // =========================
+    // Overridden Methods
+    // =========================
 
-//	public void addTransaction(Transaction transaction) {
-//		super.addTransaction(transaction);
-//	}
-
-	
-	
-	//
-	//
-	//
-	// GETTERS AND SETTERS for Block information.
-	//
-	//
-	
-	
-	
-	
-
-	public int getCurrentNodeID() {
-		return currentNodeID;
-	}
-
-
-	public void setCurrentNodeID(int currentNodeID) {
-		this.currentNodeID = currentNodeID;
-	}
-
-
-	public long getSimTime_validation() {
-		return simTime_validation;
-	}
-
-
-	public long getSysTime_validation() {
-		return sysTime_validation;
-	}
-
-
-	public int getValidationNodeID() {
-		return validationNodeID;
-	}
-
-
-	public double getValidationDifficulty() {
-		return validationDifficulty;
-	}
-
-
-	public double getValidationCycles() {
-		return validationCycles;
-	}
-	
-	
-	public void setSimTime_validation(long simTime_validation) {
-		this.simTime_validation = simTime_validation;
-	}
-
-
-	public void setSysTime_validation(long sysTime_validation) {
-		this.sysTime_validation = sysTime_validation;
-	}
-
-
-	public void setValidationDifficulty(double validationDifficulty) {
-		this.validationDifficulty = validationDifficulty;
-	}
-
-
-	public void setValidationCycles(double validationCycles) {
-		this.validationCycles = validationCycles;
-	}
-
-	
-	public String getLastBlockEvent() {
-		return lastBlockEvent;
-	}
-
-	public void setLastBlockEvent(String lastBlockEvent) {
-		this.lastBlockEvent = lastBlockEvent;
-	}
-	
-	// clone() method overriding using @Overirde
-	@Override
-	protected Object clone() throws CloneNotSupportedException {
-		return super.clone();
-	}
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
 
     @Override
     public boolean equals(Object other) {
@@ -320,13 +170,106 @@ public class Block extends TransactionGroup implements Cloneable {
                 && currentNodeID == block.currentNodeID
                 && Double.compare(validationDifficulty, block.validationDifficulty) == 0
                 && Double.compare(validationCycles, block.validationCycles) == 0
-                && Objects.equals(contx, block.contx)
+                && Objects.equals(context, block.context)
                 && Objects.equals(parent, block.parent)
                 && Objects.equals(lastBlockEvent, block.lastBlockEvent);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(contx, parent, height, simTime_validation, sysTime_validation, validationNodeID, currentNodeID, validationDifficulty, validationCycles, lastBlockEvent);
+        return Objects.hash(context, parent, height, simTime_validation, sysTime_validation, validationNodeID, currentNodeID, validationDifficulty, validationCycles, lastBlockEvent);
     }
+
+    // =========================
+    // Getters & Setters
+    // =========================
+
+    public static int getCurrID() {
+        return currID;
+    }
+
+    public static void setCurrID(int currID) {
+        Block.currID = currID;
+    }
+
+    public Context getContext() {
+        return context;
+    }
+
+    public void setContext(Context context) {
+        this.context = context;
+    }
+
+    public TransactionGroup getParent() {
+        return parent;
+    }
+
+    public void setParent(TransactionGroup parent) {
+        this.parent = parent;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public long getSimTime_validation() {
+        return simTime_validation;
+    }
+
+    public void setSimTime_validation(long simTime_validation) {
+        this.simTime_validation = simTime_validation;
+    }
+
+    public long getSysTime_validation() {
+        return sysTime_validation;
+    }
+
+    public void setSysTime_validation(long sysTime_validation) {
+        this.sysTime_validation = sysTime_validation;
+    }
+
+    public int getValidationNodeID() {
+        return validationNodeID;
+    }
+
+    public void setValidationNodeID(int validationNodeID) {
+        this.validationNodeID = validationNodeID;
+    }
+
+    public int getCurrentNodeID() {
+        return currentNodeID;
+    }
+
+    public void setCurrentNodeID(int currentNodeID) {
+        this.currentNodeID = currentNodeID;
+    }
+
+    public double getValidationDifficulty() {
+        return validationDifficulty;
+    }
+
+    public void setValidationDifficulty(double validationDifficulty) {
+        this.validationDifficulty = validationDifficulty;
+    }
+
+    public double getValidationCycles() {
+        return validationCycles;
+    }
+
+    public void setValidationCycles(double validationCycles) {
+        this.validationCycles = validationCycles;
+    }
+
+    public String getLastBlockEvent() {
+        return lastBlockEvent;
+    }
+
+    public void setLastBlockEvent(String lastBlockEvent) {
+        this.lastBlockEvent = lastBlockEvent;
+    }
+
 }

--- a/src/cmg/cnsim/bitcoin/Block.java
+++ b/src/cmg/cnsim/bitcoin/Block.java
@@ -111,7 +111,7 @@ public class Block extends TransactionGroup implements Cloneable {
      * @param cycles       The number of cycles (hashes) expended for the validation.
      */
     public void validateBlock(
-            ArrayList<Transaction> newTransList,
+            TransactionGroup newTransList,
             long simTime,
             long sysTime,
             int nodeID,
@@ -119,7 +119,7 @@ public class Block extends TransactionGroup implements Cloneable {
             double difficulty,
             double cycles
     ) {
-        super.updateTransactionGroup(newTransList);
+        super.updateTransactionGroup(newTransList.getGroup());
 //    	groupID = getID();
 
         simTime_validation = simTime;

--- a/src/cmg/cnsim/bitcoin/HonestNodeBehavior.java
+++ b/src/cmg/cnsim/bitcoin/HonestNodeBehavior.java
@@ -83,7 +83,7 @@ public class HonestNodeBehavior implements NodeBehaviorStrategy {
     public void event_NodeCompletesValidation(ITxContainer t, long time) {
         Block b = (Block) t;
         //Add validation information to the block.
-        b.validateBlock(node.miningPool.getGroup(),
+        b.validateBlock(node.miningPool,
                 Simulation.currTime,
                 System.currentTimeMillis() - Simulation.sysStartTime,
                 node.getID(),

--- a/src/cmg/cnsim/bitcoin/MaliciousNodeBehavior.java
+++ b/src/cmg/cnsim/bitcoin/MaliciousNodeBehavior.java
@@ -153,7 +153,7 @@ public class MaliciousNodeBehavior implements NodeBehaviorStrategy {
     public void event_NodeCompletesValidation(ITxContainer t, long time) {
         if (isAttackInProgress) {
             Block newBlock = (Block) t;
-            newBlock.validateBlock(node.miningPool.getGroup(), 
+            newBlock.validateBlock(node.miningPool,
             		Simulation.currTime, 
             		System.currentTimeMillis()- Simulation.sysStartTime, 
             		node.getID(), 
@@ -210,7 +210,7 @@ public class MaliciousNodeBehavior implements NodeBehaviorStrategy {
             checkAndRevealHiddenChain(newBlock);
         } else { //Attack not in progress
             Block b = (Block) t;
-            b.validateBlock(node.miningPool.getGroup(), 
+            b.validateBlock(node.miningPool,
             		Simulation.currTime, 
             		System.currentTimeMillis() - Simulation.sysStartTime, 
             		node.getID(), 

--- a/src/cmg/cnsim/bitcoin/test/BlockTest.java
+++ b/src/cmg/cnsim/bitcoin/test/BlockTest.java
@@ -2,6 +2,7 @@ package cmg.cnsim.bitcoin.test;
 
 import cmg.cnsim.bitcoin.Block;
 import cmg.cnsim.engine.transaction.Transaction;
+import cmg.cnsim.engine.transaction.TransactionGroup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -82,7 +83,7 @@ public class BlockTest {
         double cycles = 4.7;
 
         Block.Context previousContext = block.getContext();
-        block.validateBlock(newTransactions, simTime, sysTime, nodeID, eventType, difficulty, cycles);
+        block.validateBlock(new TransactionGroup(newTransactions), simTime, sysTime, nodeID, eventType, difficulty, cycles);
         Block.Context newContext = block.getContext();
 
         assertEquals(newTransactions, block.getGroup());

--- a/src/cmg/cnsim/bitcoin/test/BlockTest.java
+++ b/src/cmg/cnsim/bitcoin/test/BlockTest.java
@@ -1,0 +1,110 @@
+package cmg.cnsim.bitcoin.test;
+
+import cmg.cnsim.bitcoin.Block;
+import cmg.cnsim.engine.transaction.Transaction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BlockTest {
+
+    private ArrayList<Transaction> transactions;
+    private Block block;
+
+    @BeforeEach
+    public void setup() {
+        transactions = new ArrayList<>(Arrays.asList(
+                new Transaction(100, 1000, 322, 1892),
+                new Transaction(101, 1001, 183, 9374),
+                new Transaction(102, 1002, 238, 4192)
+        ));
+        block = new Block(transactions);
+    }
+
+    @Test
+    public void testBlockNoArgConstructor() {
+        Block block1 = new Block();
+        Block block2 = new Block();
+        Block block3 = new Block();
+
+        assertEquals(block1.getID() + 1, block2.getID());
+        assertEquals(block2.getID() + 1, block3.getID());
+    }
+
+    @Test
+    public void testBlockArgConstructor_id() {
+        Block block1 = new Block(new ArrayList<>());
+        Block block2 = new Block(new ArrayList<>(List.of(new Transaction())));
+        Block block3 = new Block(new ArrayList<>(Arrays.asList(new Transaction(), new Transaction())));
+
+        assertEquals(block1.getID() + 1, block2.getID());
+        assertEquals(block2.getID() + 1, block3.getID());
+    }
+
+    @Test
+    public void testBlockArgConstructor_transactionList() {
+        assertEquals(transactions, block.getGroup());
+    }
+
+    @Test
+    public void testValidateBlock() {
+        ArrayList<Transaction> newTransactions = new ArrayList<>(Arrays.asList(
+                new Transaction(1, 40, 322, 1892, 51383),
+                new Transaction(2, 42, 183, 9374, 66109)
+        ));
+        long simTime = 12;
+        long sysTime = 24;
+        int nodeID = 31;
+        String eventType = "Test";
+        double difficulty = 3.6;
+        double cycles = 4.7;
+
+        Block.Context previousContext = block.getContext();
+        block.validateBlock(newTransactions, simTime, sysTime, nodeID, eventType, difficulty, cycles);
+        Block.Context newContext = block.getContext();
+
+        assertEquals(newTransactions, block.getGroup());
+        assertEquals(simTime, block.getSimTime_validation());
+        assertEquals(sysTime, block.getSysTime_validation());
+        assertEquals(nodeID, block.getCurrentNodeID());
+        assertEquals(difficulty, block.getValidationDifficulty());
+        assertEquals(cycles, block.getValidationCycles());
+
+        assertNotEquals(previousContext, newContext);
+        assertEquals(simTime, newContext.simTime);
+        assertEquals(sysTime, newContext.sysTime);
+        assertEquals(nodeID, newContext.nodeID);
+        assertEquals(eventType, newContext.blockEvt);
+        assertEquals(difficulty, newContext.difficulty);
+        assertEquals(cycles, newContext.cycles);
+    }
+
+    @Test
+    public void testClone_emptyTransactions() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Block newBlock = new Block();
+
+        Method cloneMethod = Block.class.getDeclaredMethod("clone");
+        cloneMethod.setAccessible(true);
+        Block clonedBlock = (Block) cloneMethod.invoke(newBlock);
+
+        assertNotSame(newBlock, clonedBlock);
+        assertEquals(newBlock, clonedBlock);
+    }
+
+    @Test
+    public void testClone_nonEmptyTransactions() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method cloneMethod = Block.class.getDeclaredMethod("clone");
+        cloneMethod.setAccessible(true);
+        Block clonedBlock = (Block) cloneMethod.invoke(block);
+
+        assertNotSame(block, clonedBlock);
+        assertEquals(block, clonedBlock);
+    }
+}

--- a/src/cmg/cnsim/bitcoin/test/BlockTest.java
+++ b/src/cmg/cnsim/bitcoin/test/BlockTest.java
@@ -13,6 +13,9 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Unit test class for {@link Block}.
+ */
 public class BlockTest {
 
     private ArrayList<Transaction> transactions;
@@ -28,6 +31,9 @@ public class BlockTest {
         block = new Block(transactions);
     }
 
+    /**
+     * Tests {@link Block#Block()}.
+     */
     @Test
     public void testBlockNoArgConstructor() {
         Block block1 = new Block();
@@ -38,6 +44,9 @@ public class BlockTest {
         assertEquals(block2.getID() + 1, block3.getID());
     }
 
+    /**
+     * Tests {@link Block#Block(ArrayList)}.
+     */
     @Test
     public void testBlockArgConstructor_id() {
         Block block1 = new Block(new ArrayList<>());
@@ -48,11 +57,17 @@ public class BlockTest {
         assertEquals(block2.getID() + 1, block3.getID());
     }
 
+    /**
+     * Tests {@link Block#Block(ArrayList)}.
+     */
     @Test
     public void testBlockArgConstructor_transactionList() {
         assertEquals(transactions, block.getGroup());
     }
 
+    /**
+     * Tests {@link Block#validateBlock}.
+     */
     @Test
     public void testValidateBlock() {
         ArrayList<Transaction> newTransactions = new ArrayList<>(Arrays.asList(
@@ -86,6 +101,9 @@ public class BlockTest {
         assertEquals(cycles, newContext.cycles);
     }
 
+    /**
+     * Tests {@code Block#clone}
+     */
     @Test
     public void testClone_emptyTransactions() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         Block newBlock = new Block();
@@ -98,6 +116,9 @@ public class BlockTest {
         assertEquals(newBlock, clonedBlock);
     }
 
+    /**
+     * Tests {@code Block#clone}
+     */
     @Test
     public void testClone_nonEmptyTransactions() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         Method cloneMethod = Block.class.getDeclaredMethod("clone");
@@ -107,4 +128,5 @@ public class BlockTest {
         assertNotSame(block, clonedBlock);
         assertEquals(block, clonedBlock);
     }
+
 }


### PR DESCRIPTION
## CNSIMSU24-23

Changed `Block#validateBlock` parameter type from `ArrayList<Transaction>` to `TransactionGroup`. Changing the parameter type to `ITxContainer` is also feasible, but requires modifications to the interface in a future ticket (CNSIMSU24-25).

## CNSIMSU24-24

Created unit tests and re-organized the `Block` class.

Considerations before merging:
- Added setter methods for `Context` and `validationNodeID` to align with other fields. Is this addition acceptable, or was there a specific reason that these fields did not have setters?

To ensure consistency, I can create a markdown file detailing code organization conventions and IDE configurations for the team.