### PR TITLE
Add sim.output.directory and fix validateFileExists for relative paths

### DIFF
--- a/resources/config.txt
+++ b/resources/config.txt
@@ -6,6 +6,7 @@ sim.maxTransactions = 50000
 sim.reportingWindow = 100000
 sim.numofSim = 30
 sim.reporting.window = 100000
+sim.output.directory = ./log/
 
 #Network-specific parameters
 #

--- a/src/cmg/cnsim/engine/Reporter.java
+++ b/src/cmg/cnsim/engine/Reporter.java
@@ -35,6 +35,8 @@ public class Reporter {
 	protected static String root = "./log/";
 
 	static {
+		root = SimulationConfig.getOutputDirectory();
+
 		//ID the run
 		DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy.MM.dd HH.mm.ss");  
 		LocalDateTime now = LocalDateTime.now();

--- a/src/cmg/cnsim/engine/SimulationConfig.java
+++ b/src/cmg/cnsim/engine/SimulationConfig.java
@@ -1,8 +1,11 @@
 package cmg.cnsim.engine;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * Holds the configuration settings for the CNSim simulator.
@@ -109,10 +112,15 @@ public class SimulationConfig {
         if (value == null) {
             return null;
         }
-        return java.util.Arrays.stream(value.replaceAll("[{}]", "").split(","))
+        value = value.replaceAll("[{}]", "").trim();
+        if (value.isEmpty()) {
+            return new ArrayList<>(); // Return an empty list for "{}"
+        }
+        return Arrays.stream(value.split(","))
                 .map(String::trim)
+                .filter(s -> !s.isEmpty()) // Skip empty strings
                 .map(Long::parseLong)
-                .collect(java.util.stream.Collectors.toList());
+                .collect(Collectors.toList());
     }
 
     /**
@@ -158,6 +166,6 @@ public class SimulationConfig {
      * @return The output directory path.
      */
     public static String getOutputDirectory() {
-        return getPropertyString("output.directory");
+        return getPropertyString("sim.output.directory");
     }
 }

--- a/src/cmg/cnsim/engine/commandline/CommandLineParser.java
+++ b/src/cmg/cnsim/engine/commandline/CommandLineParser.java
@@ -56,7 +56,7 @@ public final class CommandLineParser {
     private String nodeFile;
 
     @CommandLineOption(
-            key = "output.directory",
+            key = "sim.output.directory",
             description = "Output directory path",
             argument = "<directory>",
             aliases = "--out"

--- a/src/cmg/cnsim/engine/commandline/test/CommandLineParserTest.java
+++ b/src/cmg/cnsim/engine/commandline/test/CommandLineParserTest.java
@@ -30,7 +30,7 @@ class CommandLineParserTest {
         assertEquals("workload.txt", properties.getProperty("workload.sampler.file"));
         assertEquals("network.txt", properties.getProperty("net.sampler.file"));
         assertEquals("node.txt", properties.getProperty("node.sampler.file"));
-        assertEquals("output/", properties.getProperty("output.directory"));
+        assertEquals("output/", properties.getProperty("sim.output.directory"));
     }
 
     @Test
@@ -100,7 +100,7 @@ class CommandLineParserTest {
         assertEquals("workload.txt", properties.getProperty("workload.sampler.file"));
         assertEquals("network.txt", properties.getProperty("net.sampler.file"));
         assertEquals("node.txt", properties.getProperty("node.sampler.file"));
-        assertEquals("output/", properties.getProperty("output.directory"));
+        assertEquals("output/", properties.getProperty("sim.output.directory"));
         assertEquals("123456", properties.getProperty("workload.sampler.seed"));
         assertEquals("{1,2,3}", properties.getProperty("node.sampler.seed"));
         assertEquals("{100,200,300}", properties.getProperty("node.sampler.seedUpdateTimes"));
@@ -123,7 +123,7 @@ class CommandLineParserTest {
         assertEquals("workload.txt", properties.getProperty("workload.sampler.file"));
         assertEquals("network.txt", properties.getProperty("net.sampler.file"));
         assertEquals("node.txt", properties.getProperty("node.sampler.file"));
-        assertEquals("output/", properties.getProperty("output.directory"));
+        assertEquals("output/", properties.getProperty("sim.output.directory"));
     }
 
     @Test


### PR DESCRIPTION
`sim.output.directory` is a new key in config.txt and allow Reporter to report logs in desired output directory.

Fixed `validateFileExists` method to resolve relative paths such as "./resources/config.txt" passed in CLI args or in config.txt. 